### PR TITLE
The CI/CD also needs to run for contributions.

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -1,6 +1,6 @@
 name: CI-CD
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
That was the whole point, how could I forget to add that??